### PR TITLE
Swapped correct Dantooine travel point names.

### DIFF
--- a/scripts/static_travel_points.py
+++ b/scripts/static_travel_points.py
@@ -49,8 +49,8 @@ def corelliaPoints(core, planet):
 def dantooinePoints(core, planet):
     trvSvc = core.travelService
     
-    trvSvc.addTravelPoint(planet, "Imperial Outpost", -635, 3, 2507)
-    trvSvc.addTravelPoint(planet, "Mining Outpost", -4208, 3, -2350)
+    trvSvc.addTravelPoint(planet, "Mining Outpost", -635, 3, 2507)
+    trvSvc.addTravelPoint(planet, "Imperial Outpost", -4208, 3, -2350)
     trvSvc.addTravelPoint(planet, "Agro Outpost", 1569, 4, -6415)
     return                
         


### PR DESCRIPTION
Imperial / Mining Outpost(s) travel point names on Dantooine were swapped - now corrected.
