### PR TITLE
Fix for 0000005: Vehicles not generating unless player moves

### DIFF
--- a/src/services/pet/MountService.java
+++ b/src/services/pet/MountService.java
@@ -22,9 +22,12 @@
 package services.pet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import protocol.swg.UpdateContainmentMessage;
 import main.NGECore;
@@ -42,6 +45,7 @@ import engine.clientdata.ClientFileManager;
 import engine.clientdata.visitors.DatatableVisitor;
 import engine.resources.container.Traverser;
 import engine.resources.objects.SWGObject;
+import engine.resources.scene.Planet;
 import engine.resources.service.INetworkDispatch;
 import engine.resources.service.INetworkRemoteEvent;
 
@@ -264,6 +268,25 @@ public class MountService implements INetworkDispatch {
 		});
 		
 		player.setCallingCompanion(false);
+		
+		// Make the vehicle visible
+		
+		List<SWGObject> newAwareObjects = core.simulationService.get(actor.getPlanet(), actor.getWorldPosition().x, actor.getWorldPosition().z, 512);
+		ArrayList<SWGObject> oldAwareObjects = new ArrayList<SWGObject>(actor.getAwareObjects());
+		@SuppressWarnings("unchecked") Collection<SWGObject> updateAwareObjects = CollectionUtils.intersection(oldAwareObjects, newAwareObjects);
+		
+		for(int i = 0; i < newAwareObjects.size(); i++) {
+			SWGObject obj = newAwareObjects.get(i);
+			//System.out.println(obj.getTemplate());
+			if(!updateAwareObjects.contains(obj) && obj != actor && !actor.getAwareObjects().contains(obj) &&  obj.getContainer() != actor && obj.isInQuadtree()) {						
+				if(obj.getAttachment("bigSpawnRange") == null && obj.getWorldPosition().getDistance2D(actor.getWorldPosition()) > 200)
+					continue;						
+				actor.makeAware(obj);
+				if(obj.getClient() != null)
+					obj.makeAware(actor);
+			}
+		}
+		
 	}
 	
 	private void callMount(CreatureObject actor, SWGObject pcd, PlayerObject player, CreatureObject mount) {


### PR DESCRIPTION
Player doesn't have to move anymore, so that the spawned vehicle will be visible
