### PR TITLE
Added Isolation Test Option

### DIFF
--- a/options.cfg
+++ b/options.cfg
@@ -5,3 +5,6 @@ LOAD.RESOURCE.SYSTEM=1
 
 # Misc
 CLEAN.ODB.FOLDERS=0
+
+# Set to 1 to have all players spawn in the desert with no NPCs around
+DO.ISOLATION.TESTS=0

--- a/src/services/CharacterService.java
+++ b/src/services/CharacterService.java
@@ -39,6 +39,7 @@ import engine.clientdata.visitors.DatatableVisitor;
 import engine.clientdata.visitors.ProfessionTemplateVisitor;
 import engine.clients.Client;
 import engine.resources.common.CRC;
+import engine.resources.config.Config;
 import engine.resources.container.CreatureContainerPermissions;
 import engine.resources.container.CreaturePermissions;
 import engine.resources.container.Traverser;
@@ -265,7 +266,16 @@ public class CharacterService implements INetworkDispatch {
 				object.setCustomName(clientCreateCharacter.getName());
 				object.setHeight(clientCreateCharacter.getScale());
 				object.setPersistent(true);
-				object.setPosition(SpawnPoint.getRandomPosition(new Point3D(3528, 0, -4804), (float) 0.5, 3, core.terrainService.getPlanetByName("tatooine").getID()));
+				
+				Config options = new Config();
+				options.setFilePath("options.cfg");
+				boolean optionsConfigLoaded = options.loadConfigFile();
+				if (optionsConfigLoaded && options.getInt("DO.ISOLATION.TESTS") > 0){
+					object.setPosition(SpawnPoint.getRandomPosition(new Point3D(0, 0, 0), (float) 0.5, 3, core.terrainService.getPlanetByName("tatooine").getID()));
+				} else {
+					object.setPosition(SpawnPoint.getRandomPosition(new Point3D(3528, 0, -4804), (float) 0.5, 3, core.terrainService.getPlanetByName("tatooine").getID()));
+				}
+				
 				object.setCashCredits(100);
 				object.setBankCredits(1000);
 				object.setIncapTimer(10);

--- a/src/services/spawn/DynamicSpawnArea.java
+++ b/src/services/spawn/DynamicSpawnArea.java
@@ -36,6 +36,7 @@ import resources.objects.creature.CreatureObject;
 import services.TerrainService;
 import services.SimulationService.MoveEvent;
 import tools.DevLog;
+import engine.resources.config.Config;
 import engine.resources.objects.SWGObject;
 import engine.resources.scene.Planet;
 import engine.resources.scene.Point3D;
@@ -59,6 +60,13 @@ public class DynamicSpawnArea extends SpawnArea {
 	@Override
 	@Handler
 	public void onEnter(EnterEvent event) {
+		
+		Config options = new Config();
+		options.setFilePath("options.cfg");
+		boolean optionsConfigLoaded = options.loadConfigFile();
+		if (optionsConfigLoaded && options.getInt("DO.ISOLATION.TESTS") > 0){
+			return;
+		}
 
 		SWGObject object = event.object;
 		// ToDo: Mounted players must be handled too

--- a/src/services/spawn/LairSpawnArea.java
+++ b/src/services/spawn/LairSpawnArea.java
@@ -34,6 +34,7 @@ import resources.objects.creature.CreatureObject;
 import services.SimulationService.MoveEvent;
 import services.TerrainService;
 import services.ai.LairActor;
+import engine.resources.config.Config;
 import engine.resources.objects.SWGObject;
 import engine.resources.scene.Planet;
 import engine.resources.scene.Point3D;
@@ -108,6 +109,13 @@ public class LairSpawnArea extends SpawnArea {
 	@Override
 	@Handler
 	public void onEnter(EnterEvent event) {
+		
+		Config options = new Config();
+		options.setFilePath("options.cfg");
+		boolean optionsConfigLoaded = options.loadConfigFile();
+		if (optionsConfigLoaded && options.getInt("DO.ISOLATION.TESTS") > 0){
+			return;
+		}
 		
 		SWGObject object = event.object;
 		

--- a/src/services/spawn/MixedSpawnArea.java
+++ b/src/services/spawn/MixedSpawnArea.java
@@ -36,6 +36,7 @@ import resources.objects.creature.CreatureObject;
 import services.TerrainService;
 import services.SimulationService.MoveEvent;
 import services.ai.LairActor;
+import engine.resources.config.Config;
 import engine.resources.objects.SWGObject;
 import engine.resources.scene.Planet;
 import engine.resources.scene.Point3D;
@@ -61,7 +62,15 @@ public class MixedSpawnArea extends SpawnArea {
 	@Override
 	@Handler
 	public void onEnter(EnterEvent event) {
-
+		
+		Config options = new Config();
+		options.setFilePath("options.cfg");
+		boolean optionsConfigLoaded = options.loadConfigFile();
+		if (optionsConfigLoaded && options.getInt("DO.ISOLATION.TESTS") > 0){
+			return;
+		}
+		
+		
 		SWGObject object = event.object;
 		// ToDo: Mounted players must be handled too
 		//System.out.println("Entering object " + object.getClass().getName());


### PR DESCRIPTION
Set to 1 in options.cfg to have all players spawn at 0,0,0 in the desert
and disable NPC/Lair spawns server-wide.
Useful to reduce clutter in packet captures for debugging purposes
