### PR TITLE
Added invasion enable option

### DIFF
--- a/options.cfg
+++ b/options.cfg
@@ -8,3 +8,6 @@ CLEAN.ODB.FOLDERS=0
 
 # Set to 1 to have all players spawn in the desert with no NPCs around
 DO.ISOLATION.TESTS=0
+
+# Set to 1 to enable GCW invasions
+ENABLE.INVASIONS=0

--- a/src/services/gcw/InvasionService.java
+++ b/src/services/gcw/InvasionService.java
@@ -66,6 +66,7 @@ import services.sui.SUIWindow.Trigger;
 import main.NGECore;
 import engine.clients.Client;
 import engine.resources.common.CRC;
+import engine.resources.config.Config;
 import engine.resources.container.Traverser;
 import engine.resources.objects.SWGObject;
 import engine.resources.scene.Planet;
@@ -138,6 +139,14 @@ public class InvasionService implements INetworkDispatch {
 	
 	public InvasionService(final NGECore core) {
 		this.core = core;	
+				
+		Config options = new Config();
+		options.setFilePath("options.cfg");
+		boolean optionsConfigLoaded = options.loadConfigFile();
+		if (optionsConfigLoaded && options.getInt("ENABLE.INVASIONS") == 0){
+			return;
+		}
+		
 		
 		// Utility code
 //		Executors.newSingleThreadScheduledExecutor().schedule(() -> {


### PR DESCRIPTION
Invasions can be toggled in options.cfg for users with
low-end machines that are not suited for calculation-intense server
operation.
