### PR TITLE
Waypoints

### DIFF
--- a/src/resources/objects/intangible/IntangibleObject.java
+++ b/src/resources/objects/intangible/IntangibleObject.java
@@ -39,6 +39,11 @@ public class IntangibleObject extends SWGObject implements Serializable {
 	
 	private transient IntangibleMessageBuilder messageBuilder;
 	
+	/*
+	 * FIXME: [MINOR] The engine code doesn't appear to use the position passed to it (at least for waypoints). When passed a not-null position,
+	 * the resulting Object comes back with a null position. The engine code in question is: engine.resource.objects.SWGObject
+	 * The bug seems to be non-fatal but appears like it might cause a memory leak.
+	 */
 	public IntangibleObject(long objectID, Planet planet, Point3D position, Quaternion orientation, String Template) {
 		super(objectID, planet, position, orientation, Template);
 	}

--- a/src/resources/objects/waypoint/WaypointObject.java
+++ b/src/resources/objects/waypoint/WaypointObject.java
@@ -43,7 +43,7 @@ public class WaypointObject extends IntangibleObject implements IDelta, Serializ
 	public static final byte BLUE = 1, GREEN = 2, ORANGE = 3, YELLOW = 4, PURPLE = 5, WHITE = 6, MULTICOLOR = 7;
 	
 	public WaypointObject(long objectID, Planet planet, Point3D position) { 
-		super(objectID, planet, new Point3D(0, 0, 0), new Quaternion(0, 0, 0, 1), "object/waypoint/shared_waypoint.iff");
+		super(objectID, planet, position, new Quaternion(0, 0, 0, 1), "object/waypoint/shared_waypoint.iff");
 	}
 	
 	public WaypointObject() {


### PR DESCRIPTION
This is my first attempt at a contribution to an external project, so if I did anything wrong please forgive me.

I managed to fix waypoints defaulting to (0,0,0). it was a simple fix, however there seems to be a problem in the Engine Code concerning engine.resources.objects.SWGObject with respect to IntangibleObject's "super" call. It seems that when "super" is called to SWGObject, it passes a legitimate "position" object, however the SWGObject that is created seems to always have a "null" position parameter. So it seems to me that the constructor call to SWGObject doesn't actually initialize its position parameter. This bug doesn't appear to be game breaking, however when ObjectService.destroy() is called in the Python script "serverdestroyobject.py" the server receives a NullPointerException. This leads me to believe that objects aren't being deleted server side, only client side, leading to possible memory leaks. Well, at least for waypoints that is.
