### PR TITLE
Enabled reusable IDs in StaticService

### DIFF
--- a/src/services/StaticService.java
+++ b/src/services/StaticService.java
@@ -140,8 +140,8 @@ public class StaticService implements INetworkDispatch {
 		}
 		
 		//long objectId = core.objectService.getDOId(planetName, template, 0, buildingId, cellNumber, x, y, z);
-		//long objectId = core.objectService.getReusableId();
-		long objectId = 0;
+		long objectId = core.objectService.getReusableId();
+		//long objectId = 0;
 		SWGObject object = null;
 		
 		MobileTemplate mobileTemplate = core.spawnService.getMobileTemplate(template);


### PR DESCRIPTION
Needs testing to see if reusableIds cause crashes.  Previously DOIds were suspected to be causing crashes with StaticService so we need to see if this alternative system of reusableIds causes them or not.
