### PR TITLE
Fixes database lock exceptions

### DIFF
--- a/src/services/object/ObjectService.java
+++ b/src/services/object/ObjectService.java
@@ -205,6 +205,8 @@ public class ObjectService implements INetworkDispatch {
 				objectList.put(object.getObjectID(), object);
 		}
 		
+		cursor.close(); // Has always to be closed properly or will create undefined locking behaviour!
+		
 		cursor = core.getReusableIdODB().getCursor();
 		
 		while (cursor.hasNext()) {
@@ -212,6 +214,9 @@ public class ObjectService implements INetworkDispatch {
 		}
 		
 		loadBuildings();
+		
+		cursor.close(); // Has always to be closed properly or will create undefined locking behaviour!
+		
 		System.out.println("Finished loading objects.");
 	}
 	


### PR DESCRIPTION
Thus fixing characters not loading their data correctly from the
database after server-restart. Database engine-related lock file stats should be correct now.
