### PR TITLE
Fixed up Tipping

### DIFF
--- a/scripts/commands/tip.py
+++ b/scripts/commands/tip.py
@@ -37,7 +37,6 @@ def run(core, actor, target, commandString):
     actorID = actor.getObjectID()
     commandArgs = commandString.split(" ")
     commandLength = len(commandArgs)
-    bankSurcharge = int(math.ceil(0.05 * float(tipAmount))) # Accurate tipping tax - prevents floating point error
     
     # Determine type of tip
     if not commandArgs[0].isdigit():
@@ -61,6 +60,8 @@ def run(core, actor, target, commandString):
             else:
                 actor.sendSystemMessage('Unrecognized tip command', 0)
                 return
+
+    bankSurcharge = int(math.ceil(0.05 * float(tipAmount))) # Accurate tipping tax - prevents floating point error
     
     
     #/tip int || /tip target int


### PR DESCRIPTION
Appears to be working well cross planet.

Working:
/tip name 1000
/tip 1000 (with target)
/tip name 1000 bank
/tip 1000 bank (with target)

Not 100% sure how tipping worked in NGE, but currently 'target' is passed into the function as the current mouseover target. /tip 1000 if you only have somebody targeted (but not moused over) fails to tip.
